### PR TITLE
DHCP Client now remembers previous IP

### DIFF
--- a/NetworkControl/DHCPClientImplementation.cpp
+++ b/NetworkControl/DHCPClientImplementation.cpp
@@ -97,16 +97,7 @@ namespace Plugin {
     {
         if (!_persistentStorage.empty()) {
             Core::File file(_persistentStorage + lastIPFileName);
-            bool isFileOpen = false;
-
-            if (file.Exists()) {
-                isFileOpen = file.Open(false);
-                file.SetSize(0);
-            } else {
-                isFileOpen = file.Create();
-            }
-
-            if (isFileOpen) {
+            if (file.Create()) {
                 IPStorage storage;
                 storage.ip_adress = last_ip.c_str();
                 storage.ToFile(file);

--- a/NetworkControl/DHCPClientImplementation.h
+++ b/NetworkControl/DHCPClientImplementation.h
@@ -144,6 +144,10 @@ namespace Plugin {
         static constexpr uint16_t DefaultDHCPClientPort = 68;
 
         class IPStorage : public Core::JSON::Container {
+        private:
+            IPStorage(const IPStorage&) = delete;
+            IPStorage& operator=(const IPStorage&) = delete;
+
         public:
             IPStorage() 
                 : Core::JSON::Container()

--- a/NetworkControl/DHCPClientImplementation.h
+++ b/NetworkControl/DHCPClientImplementation.h
@@ -32,6 +32,9 @@ namespace Plugin {
             RECEIVING
         };
 
+        // Name of file containing last ip
+        static constexpr TCHAR lastIPFileName[] = _T("dhcpclient.json");
+
         // RFC 2131 section 2
         enum operations {
             OPERATION_BOOTREQUEST = 1,
@@ -139,6 +142,18 @@ namespace Plugin {
         // DHCP constants (see RFC 2131 section 4.1)
         static constexpr uint16_t DefaultDHCPServerPort = 67;
         static constexpr uint16_t DefaultDHCPClientPort = 68;
+
+        class IPStorage : public Core::JSON::Container {
+        public:
+            IPStorage() 
+                : Core::JSON::Container()
+                , ip_adress()
+            {
+                Add(_T("ip_address"), &ip_adress);
+            }
+        public:
+            Core::JSON::String ip_adress;
+        };
 
         class Offer {
         public:
@@ -357,7 +372,7 @@ namespace Plugin {
         typedef Core::IDispatchType<const string&> ICallback;
 
     public:
-        DHCPClientImplementation(const string& interfaceName, ICallback* notification);
+        DHCPClientImplementation(const string& interfaceName, ICallback* notification, const string& persistentStoragePath);
         virtual ~DHCPClientImplementation();
 
     public:
@@ -408,7 +423,7 @@ namespace Plugin {
 
                         _state = SENDING;
                         _modus = CLASSIFICATION_DISCOVER;
-                        _preferred = address;
+                        _preferred = address.IsEmpty() ? _last : address;
                         result = Core::ERROR_NONE;
 
                         TRACE_L1("Sending a Discover for %s", _interfaceName.c_str());
@@ -438,10 +453,14 @@ namespace Plugin {
 
             _adminLock.Lock();
 
+            if (acknowledged.HostAddress() != _last.HostAddress()) {
+                SaveLastIP(acknowledged.HostAddress());
+            }
+
             if (_state == RECEIVING) {
                 TRACE_L1("Sending an ACK for %s", acknowledged.HostAddress().c_str());
                 _state = SENDING;
-                _modus = CLASSIFICATION_ACK;
+                _modus = CLASSIFICATION_REQUEST;
                 _preferred = acknowledged;
                 result = Core::ERROR_NONE;
                 SocketDatagram::Trigger();
@@ -485,6 +504,10 @@ namespace Plugin {
         }
 
     private:
+        // Methods for retaining IP adress over reboots
+        string ReadLastIP();
+        void SaveLastIP(const string& last_ip);
+
         // Methods to extract and insert data into the socket buffers
         virtual uint16_t SendData(uint8_t* dataFrame, const uint16_t maxSendSize) override;
         virtual uint16_t ReceiveData(uint8_t* dataFrame, const uint16_t receivedSize) override;
@@ -550,6 +573,14 @@ namespace Plugin {
                 ::memcpy(&(options[index]), &(data->sin_addr.s_addr), 4);
                 index += 4;
             }
+
+            /* Add identifier so that DHCP server can recognize device */
+            options[index++] = OPTION_CLIENTIDENTIFIER;
+            options[index++] = frame.hlen + 1; // Identifier length
+            options[index++] = 1; // Ethernet hardware
+            ::memcpy(&(options[index]), _MAC, frame.hlen);
+            index += frame.hlen;
+
             if (_modus == CLASSIFICATION_DISCOVER) {
                 options[index++] = OPTION_REQUESTLIST;
                 options[index++] = 4;
@@ -557,7 +588,7 @@ namespace Plugin {
                 options[index++] = OPTION_ROUTER;
                 options[index++] = OPTION_DNS;
                 options[index++] = OPTION_BROADCASTADDRESS;
-            }
+            } 
 
             options[index++] = OPTION_END;
 
@@ -603,8 +634,10 @@ namespace Plugin {
         uint8_t _MAC[6];
         mutable uint32_t _xid;
         Core::NodeId _preferred;
+        Core::NodeId _last;
         ICallback* _callback;
         std::list<Offer> _offers;
+        string _persistentStorage;
     };
 }
 } // namespace WPEFramework::Plugin

--- a/NetworkControl/NetworkControl.cpp
+++ b/NetworkControl/NetworkControl.cpp
@@ -62,6 +62,7 @@ namespace Plugin
         , _service(nullptr)
         , _responseTime(0)
         , _retries(0)
+        , _persistentStoragePath()
         , _dns()
         , _interfaces()
         , _dhcpInterfaces()
@@ -88,6 +89,8 @@ namespace Plugin
         _skipURL = static_cast<uint8_t>(service->WebPrefix().length());
         _responseTime = config.TimeOut.Value();
         _dnsFile = config.DNSFile.Value();
+
+        _persistentStoragePath = service->PersistentPath();
 
         // We will only "open" the DNS resolve file, so of ot does not exist yet, create an empty file.
         Core::File dnsFile(_dnsFile, true);
@@ -127,7 +130,7 @@ namespace Plugin
 
                     _dhcpInterfaces.emplace(std::piecewise_construct,
                         std::make_tuple(interfaceName),
-                        std::make_tuple(Core::ProxyType<DHCPEngine>::Create(this, interfaceName)));
+                        std::make_tuple(Core::ProxyType<DHCPEngine>::Create(this, interfaceName, _persistentStoragePath)));
                     _interfaces.emplace(std::piecewise_construct,
                         std::make_tuple(interfaceName),
                         std::make_tuple(index.Current()));
@@ -158,7 +161,7 @@ namespace Plugin
                 if (_interfaces.find(interfaceName) == _interfaces.end()) {
                     _dhcpInterfaces.emplace(std::piecewise_construct,
                         std::make_tuple(interfaceName),
-                        std::make_tuple(Core::ProxyType<DHCPEngine>::Create(this, interfaceName)));
+                        std::make_tuple(Core::ProxyType<DHCPEngine>::Create(this, interfaceName, _persistentStoragePath)));
                     _interfaces.emplace(std::piecewise_construct,
                         std::make_tuple(interfaceName),
                         std::make_tuple(StaticInfo()));
@@ -548,7 +551,6 @@ namespace Plugin
 
     void NetworkControl::Update(const string& interfaceName)
     {
-
         std::map<const string, Core::ProxyType<DHCPEngine>>::const_iterator entry(_dhcpInterfaces.find(interfaceName));
 
         if (entry != _dhcpInterfaces.end()) {
@@ -718,7 +720,7 @@ namespace Plugin
             if (_interfaces.find(interfaceName) == _interfaces.end()) {
                 _dhcpInterfaces.emplace(std::piecewise_construct,
                     std::make_tuple(interfaceName),
-                    std::make_tuple(Core::ProxyType<DHCPEngine>::Create(this, interfaceName)));
+                    std::make_tuple(Core::ProxyType<DHCPEngine>::Create(this, interfaceName, _persistentStoragePath)));
                 _interfaces.emplace(std::piecewise_construct,
                     std::make_tuple(interfaceName),
                     std::make_tuple(StaticInfo()));

--- a/NetworkControl/NetworkControl.h
+++ b/NetworkControl/NetworkControl.h
@@ -283,10 +283,10 @@ namespace Plugin {
             DHCPEngine& operator=(const DHCPEngine&) = delete;
 
         public:
-            DHCPEngine(NetworkControl* parent, const string& interfaceName)
+            DHCPEngine(NetworkControl* parent, const string& interfaceName, const string& persistentStoragePath)
                 : _parent(*parent)
                 , _retries(0)
-                , _client(interfaceName, this)
+                , _client(interfaceName, this, persistentStoragePath)
             {
             }
             ~DHCPEngine()
@@ -438,6 +438,7 @@ namespace Plugin {
         uint8_t _responseTime;
         uint8_t _retries;
         string _dnsFile;
+        string _persistentStoragePath;
         std::list<std::pair<uint16_t, Core::NodeId>> _dns;
         std::map<const string, StaticInfo> _interfaces;
         std::map<const string, Core::ProxyType<DHCPEngine>> _dhcpInterfaces;


### PR DESCRIPTION
1. Fixed DHCP client sending ACK instead of REQUEST
2. Added IP retention - it is no longer changing on every reboot 