### PR TITLE
Compositor: link to NexusServer restored

### DIFF
--- a/Compositor/lib/Wayland/NexusServer
+++ b/Compositor/lib/Wayland/NexusServer
@@ -1,0 +1,1 @@
+../Nexus/NexusServer


### PR DESCRIPTION
@pwielders, wayland build for nexus is failing since the NexusServer link is not available in the expected path. Found that the link to NexusServer was removed @Commit: https://github.com/WebPlatformForEmbedded/ThunderNanoServices/commit/c0519fafc9b6177e6391f4381c62be7604c62f0d#diff-ae058ed81423bf369a3a1e5dd6ebb0d2L1. So I am note sure, can I restore it again.