### PR TITLE
[compositor] Add nxserver include dirs to target.

### DIFF
--- a/Compositor/lib/Nexus/CMakeLists.txt
+++ b/Compositor/lib/Nexus/CMakeLists.txt
@@ -38,6 +38,11 @@ else()
             INCLUDE_NEXUS_SERVER
             )
 
+    target_include_directories(${TARGET}
+        PRIVATE
+            ${LIBNXSERVER_INCLUDE_DIR}
+    )
+
     target_link_libraries(${TARGET}
         PRIVATE
             ${NAMESPACE}nexusserver::${NAMESPACE}nexusserver

--- a/Compositor/lib/Nexus/NexusServer/CMakeLists.txt
+++ b/Compositor/lib/Nexus/NexusServer/CMakeLists.txt
@@ -34,6 +34,12 @@ else()
     find_package(NXSERVER REQUIRED)
     find_package(NEXUS REQUIRED)
     find_package(NXCLIENT_LOCAL REQUIRED)
+
+    target_include_directories(${TARGET}
+        PRIVATE
+            ${LIBNXSERVER_INCLUDE_DIR}
+    )
+
     target_link_libraries(${TARGET}
         PRIVATE
             ${NAMESPACE}Core::${NAMESPACE}Core


### PR DESCRIPTION
This fixes an error of a header file not found:
Compositor/lib/Nexus/NexusServer/NexusServer.h:6:25: fatal error: nxserverlib.h: No such file or directory
 #include <nxserverlib.h>

Fixed by adding /usr/include/nxclient path as part of the include, as found per FindNXSERVER.cmake.

Ran into the above error on Yocto, can the cmake gods check this for me please? @bramoosterhuis 