### PR TITLE
[WifiControl] BSSID is uint64_t and it's written to a JSON string.

### DIFF
--- a/WifiControl/WifiControl.h
+++ b/WifiControl/WifiControl.h
@@ -142,7 +142,7 @@ namespace Plugin {
 
         static void FillNetworkInfo(const WPASupplicant::Network& info, JsonData::WifiControl::NetworkInfo& net)
         {
-            net.Bssid = info.BSSID();
+            net.Bssid = std::to_string(info.BSSID());
             net.Frequency = info.Frequency();
             net.Signal = info.Signal();
             net.Ssid = info.SSID();


### PR DESCRIPTION
Via implicit conversions with String(bool quoted) involved.
The mentioned Ctor will be made explicit as a separate change.