### PR TITLE
[OpenCDMi] Fix empty keysystems in jsonrpc

### DIFF
--- a/OpenCDMi/OCDMJsonRpc.cpp
+++ b/OpenCDMi/OCDMJsonRpc.cpp
@@ -31,7 +31,10 @@ namespace Plugin {
         if (keySystemsIter != nullptr) {
             string element;
             while (keySystemsIter->Next(element) == true) {
-                response.Add(Core::JSON::String(element));
+                Core::JSON::String designator;
+                designator = element;
+
+                response.Add(designator);
             }
 
             keySystemsIter->Release();


### PR DESCRIPTION
Fixed problem with empty keysystems returned in jsonrpc request to ocdm plugin.
Jira ticket WPE-320