### PR TITLE
Spark: Only check STREQUAL if value exists

### DIFF
--- a/Spark/Spark.config
+++ b/Spark/Spark.config
@@ -7,7 +7,7 @@ end()
 ans(configuration)
 
 map()
-if (${PLUGIN_COMPOSITOR_IMPLEMENTATION} STREQUAL "RPI")
+if (${PLUGIN_COMPOSITOR_IMPLEMENTATION} AND ${PLUGIN_COMPOSITOR_IMPLEMENTATION} STREQUAL "RPI")
     kv(threads 2)
 end()
 ans(rootconfig)


### PR DESCRIPTION
This fixes an error when trying to compile Spark without Compositor. Without Compositor the value ${PLUGIN_COMPOSITOR_IMPLEMENTATION} is not present.