### PR TITLE
wpeframework-plugins: Linking InjectedBundle cpp files to resolve

### DIFF
--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -42,6 +42,11 @@ add_library(${MODULE_NAME} SHARED
     WebKitImplementation.cpp
     InjectedBundle/WhiteListedOriginDomainsList.cpp
     InjectedBundle/Utils.cpp
+    InjectedBundle/main.cpp
+    InjectedBundle/Milestone.cpp
+    InjectedBundle/NotifyWPEFramework.cpp
+    InjectedBundle/ClassDefinition.cpp
+    InjectedBundle/JavaScriptFunction.cpp
 )
 
 set_target_properties(${MODULE_NAME} PROPERTIES

--- a/WebKitBrowser/InjectedBundle/main.cpp
+++ b/WebKitBrowser/InjectedBundle/main.cpp
@@ -263,9 +263,6 @@ static WKBundleClientV1 s_bundleClient = {
     nullptr, // didReceiveMessageToPage
 };
 
-// Declare module name for tracer.
-MODULE_NAME_DECLARATION(BUILD_REFERENCE)
-
 void WKBundleInitialize(WKBundleRef bundle, WKTypeRef)
 {
     g_Bundle = bundle;


### PR DESCRIPTION
undefined symbols in WPEFramework and removing module name declaration
as its conflicting WebKitBrowser cpp(Module.cpp) file.

Signed-off-by: rkhan467 <Riyaz_Khan@comcast.com>