### PR TITLE
[WPE-357][WPE-356][DHCPClient] Full implementation of minimal dhcp protocol

### DIFF
--- a/NetworkControl/NetworkControl.config
+++ b/NetworkControl/NetworkControl.config
@@ -2,6 +2,8 @@ set(autostart true)
 
 map()
     kv(dnsfile "/etc/resolv.conf")
+    kv(timeout 5)
+    kv(retries 4)
     kv(interfaces ___array___)
     map()
         kv(interface wlan0)


### PR DESCRIPTION
[WPE-357]
The socket is now properly closed when either DHCP successfully assing IP or a maximum number of retries were exceeded.

[WPE-356]
DHCPImplementation is now not aware of permanent storage. Its sole responsibility is to implement DHCP requests and process responses.  Moreover, now the only DHCPRequest is sent if IP was saved, which is correct behaviour in such a case. Full DHCPDisover is sent only if DHCPRequest fails.  Also, multiple interfaces are supported now.

[DHCPClient] - Full implementation
Previously IP was assigned only after receiving information, that this IP is available. Result of the request was ignored. Now IP is assigned only after it is successfully given by DHCP server. If the server refuses to assign IP, other offers are tried or another DHCPDiscover is issued if no other options are available. 