### PR TITLE
[WPE-220][DHCPServer] Saving ip leases to permanent storage

### DIFF
--- a/DHCPServer/DHCPServerImplementation.cpp
+++ b/DHCPServer/DHCPServerImplementation.cpp
@@ -5,6 +5,7 @@ namespace WPEFramework {
 namespace Plugin {
 
     /* static */ constexpr uint8_t DHCPServerImplementation::MagicCookie[];
+    /* static */ constexpr uint16_t DHCPServerImplementation::Identifier::maxLength;
 
     uint32_t DHCPServerImplementation::Open()
     {


### PR DESCRIPTION
Leased IP are now stored over reboots, so devices should get the same ip.

# Testing
It's easiest to test via creating access point on wifi interface but to do this at least somewhat reliable https://github.com/WebPlatformForEmbedded/ThunderNanoServices/pull/171 needs to be merged first