### PR TITLE
[NetworkControll ] Fixed using Open() instead of Create() while saving leases

### DIFF
--- a/NetworkControl/NetworkControl.cpp
+++ b/NetworkControl/NetworkControl.cpp
@@ -429,7 +429,9 @@ namespace Plugin
     void NetworkControl::DHCPEngine::SaveLeases() 
     {
         if (_parent._persistentStoragePath.empty() == false) {
-            if (_leaseFile.Create() == true) {
+            Core::File leaseFile(_leaseFilePath);
+
+            if (leaseFile.Create() == true) {
                 Core::JSON::ArrayType<DHCPClientImplementation::Offer::JSON> leases;
                 DHCPClientImplementation::Iterator offersIterator = _client.Offers(true);
 
@@ -437,13 +439,13 @@ namespace Plugin
                     leases.Add().Set(offersIterator.Current());
                 }
 
-                if (leases.ToFile(_leaseFile) == false) {
+                if (leases.ToFile(leaseFile) == false) {
                     TRACE(Trace::Warning, ("Error occured while trying to save dhcp leases to file!"));
                 } 
 
-                _leaseFile.Close();
+                leaseFile.Close();
             } else {
-                TRACE(Trace::Warning, ("Failed to open leases file %s\n for saving", _leaseFile.Name().c_str()));
+                TRACE(Trace::Warning, ("Failed to open leases file %s\n for saving", leaseFile.Name().c_str()));
             }
         }
     }
@@ -456,10 +458,12 @@ namespace Plugin
     {
         if (_parent._persistentStoragePath.empty() == false) {
 
-            if (_leaseFile.Open(true) == true) {
+            Core::File leaseFile(_leaseFilePath);
+
+            if (leaseFile.Open(true) == true) {
 
                 Core::JSON::ArrayType<DHCPClientImplementation::Offer::JSON> leases;
-                if (leases.FromFile(_leaseFile) == true) {
+                if (leases.FromFile(leaseFile) == true) {
 
                     auto iterator = leases.Elements();
                     while (iterator.Next()) {
@@ -467,9 +471,9 @@ namespace Plugin
                     }
                 }
 
-                _leaseFile.Close();
+                leaseFile.Close();
             } else {
-                TRACE(Trace::Warning, ("Failed to open leases file %s\n for saving", _leaseFile.Name().c_str()));
+                TRACE(Trace::Warning, ("Failed to open leases file %s\n for saving", leaseFile.Name().c_str()));
             }
         }
     }

--- a/NetworkControl/NetworkControl.cpp
+++ b/NetworkControl/NetworkControl.cpp
@@ -429,7 +429,7 @@ namespace Plugin
     void NetworkControl::DHCPEngine::SaveLeases() 
     {
         if (_parent._persistentStoragePath.empty() == false) {
-            if (leaseFile.Open(false) == true) {
+            if (_leaseFile.Create() == true) {
                 Core::JSON::ArrayType<DHCPClientImplementation::Offer::JSON> leases;
                 DHCPClientImplementation::Iterator offersIterator = _client.Offers(true);
 
@@ -437,13 +437,13 @@ namespace Plugin
                     leases.Add().Set(offersIterator.Current());
                 }
 
-                if (leases.ToFile(leaseFile) == false) {
-                    TRACE_L1("Error while trying to save dhcp leases to file!");
+                if (leases.ToFile(_leaseFile) == false) {
+                    TRACE(Trace::Warning, ("Error occured while trying to save dhcp leases to file!"));
                 } 
 
-                leaseFile.Close();
+                _leaseFile.Close();
             } else {
-                TRACE_L1("Failed to open leases file %s\n for saving", leaseFile.Name().c_str());
+                TRACE(Trace::Warning, ("Failed to open leases file %s\n for saving", _leaseFile.Name().c_str()));
             }
         }
     }
@@ -456,10 +456,10 @@ namespace Plugin
     {
         if (_parent._persistentStoragePath.empty() == false) {
 
-            if (leaseFile.Open(true) == true) {
+            if (_leaseFile.Open(true) == true) {
 
                 Core::JSON::ArrayType<DHCPClientImplementation::Offer::JSON> leases;
-                if (leases.FromFile(leaseFile) == true) {
+                if (leases.FromFile(_leaseFile) == true) {
 
                     auto iterator = leases.Elements();
                     while (iterator.Next()) {
@@ -467,9 +467,9 @@ namespace Plugin
                     }
                 }
 
-                leaseFile.Close();
+                _leaseFile.Close();
             } else {
-                TRACE_L1("Failed to open leases file %s\n for saving", leaseFile.Name().c_str());
+                TRACE(Trace::Warning, ("Failed to open leases file %s\n for saving", _leaseFile.Name().c_str()));
             }
         }
     }

--- a/NetworkControl/NetworkControl.h
+++ b/NetworkControl/NetworkControl.h
@@ -290,12 +290,17 @@ namespace Plugin {
                 , _retries(0)
                 , _client(interfaceName, std::bind(&DHCPEngine::NewOffer, this, std::placeholders::_1), 
                           std::bind(&DHCPEngine::RequestResult, this, std::placeholders::_1, std::placeholders::_2))
-                , leaseFile(persistentStoragePath + _client.Interface() + ".json")
+                , _leaseFile(persistentStoragePath + _client.Interface() + ".json")
             {
 
                 // Make sure that lease file exists
-                if ((persistentStoragePath.empty() == false) && (leaseFile.Exists() == false)) {
-                    leaseFile.Create();
+                if ((persistentStoragePath.empty() == false) && (_leaseFile.Exists() == false)) {
+                    if (_leaseFile.Create() == true) {
+                        _leaseFile.Close();
+                    } else {
+                        TRACE(Trace::Warning, ("Failed to create persistent dhcp lease file for %s", interfaceName.c_str()))
+                    }
+                    
                 }
             }
             ~DHCPEngine()
@@ -440,7 +445,7 @@ namespace Plugin {
             NetworkControl& _parent;
             uint8_t _retries;
             DHCPClientImplementation _client;
-            Core::File leaseFile;
+            Core::File _leaseFile;
         };
 
     private:

--- a/NetworkControl/NetworkControl.h
+++ b/NetworkControl/NetworkControl.h
@@ -290,15 +290,18 @@ namespace Plugin {
                 , _retries(0)
                 , _client(interfaceName, std::bind(&DHCPEngine::NewOffer, this, std::placeholders::_1), 
                           std::bind(&DHCPEngine::RequestResult, this, std::placeholders::_1, std::placeholders::_2))
-                , _leaseFile(persistentStoragePath + _client.Interface() + ".json")
+                , _leaseFilePath(persistentStoragePath + _client.Interface() + ".json")
             {
-
                 // Make sure that lease file exists
-                if ((persistentStoragePath.empty() == false) && (_leaseFile.Exists() == false)) {
-                    if (_leaseFile.Create() == true) {
-                        _leaseFile.Close();
-                    } else {
-                        TRACE(Trace::Warning, ("Failed to create persistent dhcp lease file for %s", interfaceName.c_str()))
+                if (persistentStoragePath.empty() == false) {
+                    Core::File leaseFile(_leaseFilePath);
+
+                    if (leaseFile.Exists() == false) {
+                        if (leaseFile.Create() == true) {
+                            leaseFile.Close();
+                        } else {
+                            TRACE(Trace::Warning, ("Failed to create persistent dhcp lease file for %s", interfaceName.c_str()))
+                        }
                     }
                     
                 }
@@ -445,7 +448,7 @@ namespace Plugin {
             NetworkControl& _parent;
             uint8_t _retries;
             DHCPClientImplementation _client;
-            Core::File _leaseFile;
+            string _leaseFilePath;
         };
 
     private:


### PR DESCRIPTION
SaveLeases() function was mistakenly using Open() instead of Create() - that caused the lease file not to be truncated before saving. 

This could lead to a corrupted file if a new version of the file was shorter than the previous one.
Also changed "leaseFile" to "_leaseFile" to better follow convention.

Caught by @sebaszm 