### PR TITLE
RemoteControl: Add: Changes to get pairing events

### DIFF
--- a/RemoteControl/IRRemote.cpp
+++ b/RemoteControl/IRRemote.cpp
@@ -73,6 +73,8 @@ namespace Plugin {
         virtual uint32_t Callback(Exchange::IKeyHandler* callback);
         virtual uint32_t Error() const;
         virtual string MetaData() const;
+        virtual void RegisterKeyProducerEvents(IKeyProducer::INotification* sink);
+        virtual void UnregisterKeyProducerEvents(IKeyProducer::INotification* sink);
 
     private:
         static void NexusCallback(void* nexusIRHandle, int deviceID);
@@ -202,6 +204,15 @@ namespace Plugin {
     /* virtual */ string IRRemote::MetaData() const
     {
         return _T("BCM Nexus");
+    }
+
+
+    /* virtual */ void RegisterKeyProducerEvents(IKeyProducer::INotification* sink) {
+        TRACE_L1("There are no events written for IRRemote producer");
+    }
+
+    /* virtual */ void UnregisterKeyProducerEvents(IKeyProducer::INotification* sink) {
+        TRACE_L1("There are no events written for IRRemote producer");
     }
 
     /* static */ void IRRemote::NexusCallback(void* nexusIRHandle, int deviceID)

--- a/RemoteControl/LinuxDevice.cpp
+++ b/RemoteControl/LinuxDevice.cpp
@@ -80,6 +80,14 @@ namespace Plugin {
                 return false;
             }
 
+            void RegisterKeyProducerEvents(IKeyProducer::INotification* sink) {
+                TRACE_L1("There are no events written for LinuxDevice producer");
+            }
+
+            void UnregisterKeyProducerEvents(IKeyProducer::INotification* sink) {
+                TRACE_L1("There are no events written for LinuxDevice producer");
+            }
+
             BEGIN_INTERFACE_MAP(KeyDevice)
             INTERFACE_ENTRY(Exchange::IKeyProducer)
             END_INTERFACE_MAP


### PR DESCRIPTION
This commit adds the changes needed to get events from RemoteControl
plugin about the RF4CE pairing states.

Currently changes are added for getting PairingStarted, PairingSuccess,
PairingFailed and PairingTimedout.

Since we had to modify IKeyProducer interface to get events from
GreenPeak producer in RemoteControl plugin. We will also need to
implement the new methods in LinuxDevice, and IRRemote which are also
KeyProducers.

Since there are no events from LinuxDevice, IRRemote. The implementation
of the Register and Unregister calls are left unimplemented.

Signed-off-by: harikrishnan.p <harikris2012@gmail.com>

Depends on #https://github.com/WebPlatformForEmbedded/Thunder/pull/238