### PR TITLE
Streamer: Fixes from NOS testing

### DIFF
--- a/Streamer/Streamer.cpp
+++ b/Streamer/Streamer.cpp
@@ -2,6 +2,27 @@
 
 namespace WPEFramework {
 
+    ENUM_CONVERSION_BEGIN(Exchange::IStream::streamtype)
+        { Exchange::IStream::streamtype::Undefined, _TXT(_T("Undefined")) },
+        { Exchange::IStream::streamtype::Cable, _TXT(_T("Cable")) },
+        { Exchange::IStream::streamtype::Handheld, _TXT(_T("Handheld")) },
+        { Exchange::IStream::streamtype::Satellite, _TXT(_T("Satellite")) },
+        { Exchange::IStream::streamtype::Terrestrial, _TXT(_T("Terrestrial")) },
+        { Exchange::IStream::streamtype::DAB, _TXT(_T("DAB")) },
+        { Exchange::IStream::streamtype::RF, _TXT(_T("RF")) },
+        { Exchange::IStream::streamtype::Unicast, _TXT(_T("Unicast")) },
+        { Exchange::IStream::streamtype::Multicast, _TXT(_T("Multicast")) },
+        { Exchange::IStream::streamtype::IP, _TXT(_T("IP")) },
+    ENUM_CONVERSION_END(Exchange::IStream::streamtype)
+
+    ENUM_CONVERSION_BEGIN(Exchange::IStream::state)
+        { Exchange::IStream::state::Idle, _TXT(_T("Idle")) },
+        { Exchange::IStream::state::Loading, _TXT(_T("Loading")) },
+        { Exchange::IStream::state::Prepared, _TXT(_T("Prepared")) },
+        { Exchange::IStream::state::Controlled, _TXT(_T("Controlled")) },
+        { Exchange::IStream::state::Error, _TXT(_T("Error")) },
+    ENUM_CONVERSION_END(Exchange::IStream::state)
+
 namespace Plugin {
 
     SERVICE_REGISTRATION(Streamer, 1, 0);

--- a/Streamer/Streamer.cpp
+++ b/Streamer/Streamer.cpp
@@ -42,6 +42,11 @@ namespace Plugin {
         _skipURL = _service->WebPrefix().length();
 
         config.FromString(_service->ConfigLine());
+
+        // Register the Process::Notification stuff. The Remote process might die before we get a
+        // change to "register" the sink for these events !!! So do it ahead of instantiation.
+        _service->Register(&_notification);
+
         _player = _service->Root<Exchange::IPlayer>(_connectionId, 2000, _T("StreamerImplementation"));
 
         if ((_player != nullptr) && (_service != nullptr)) {
@@ -61,6 +66,7 @@ namespace Plugin {
         } else {
             TRACE(Trace::Error, (_T("Streamer could not be initialized.")));
             message = _T("Streamer could not be initialized.");
+            _service->Unregister(&_notification);
         }
 
         return message;
@@ -70,6 +76,8 @@ namespace Plugin {
     {
         ASSERT(_service == service);
         ASSERT(_player != nullptr);
+
+        service->Unregister(&_notification);
 
         if (_player->Release() != Core::ERROR_DESTRUCTION_SUCCEEDED) {
 

--- a/Streamer/Streamer.h
+++ b/Streamer/Streamer.h
@@ -12,6 +12,39 @@ namespace Plugin {
         Streamer(const Streamer&) = delete;
         Streamer& operator=(const Streamer&) = delete;
 
+        class Notification : public RPC::IRemoteConnection::INotification {
+        private:
+            Notification() = delete;
+            Notification(const Notification&) = delete;
+            Notification& operator=(const Notification&) = delete;
+
+        public:
+            explicit Notification(Streamer* parent)
+                : _parent(*parent)
+            {
+                ASSERT(parent != nullptr);
+            }
+            virtual ~Notification()
+            {
+            }
+
+        public:
+            virtual void Activated(RPC::IRemoteConnection* connection)
+            {
+            }
+            virtual void Deactivated(RPC::IRemoteConnection* connection)
+            {
+                _parent.Deactivated(connection);
+            }
+
+            BEGIN_INTERFACE_MAP(Notification)
+                INTERFACE_ENTRY(RPC::IRemoteConnection::INotification)
+            END_INTERFACE_MAP
+
+        private:
+            Streamer& _parent;
+        };
+
         class StreamProxy {
         private:
             class StreamSink : public Exchange::IStream::ICallback {
@@ -277,6 +310,7 @@ namespace Plugin {
             , _connectionId(0)
             , _service(nullptr)
             , _player(nullptr)
+            , _notification(this)
             , _streams()
             , _controls()
         {
@@ -413,6 +447,7 @@ namespace Plugin {
         PluginHost::IShell* _service;
 
         Exchange::IPlayer* _player;
+        Core::Sink<Notification> _notification;
 
         // Stream and StreamControl holding areas for the RESTFull API.
         Streams _streams;


### PR DESCRIPTION
A few Streamer plugin fixes drafted after NOS testing with the latest framework.

Commit 1 (f2d1a9cbf646) fixes missing enum conversion tables.  
Commit 2 (c21973d31c03) fixes implementation for the ExternalAccess class to be according the the latest Thunder requirements.  
Commit 3 (c312b7e0e4ac) adds a missing registration to `RPC::IRemoteConnection::INotification`.

All of the fixes are required for correct operation of the Streamer plugin under the use cases required by NOS.