### PR TITLE
Compositor: Fixes from NOS testing

### DIFF
--- a/Compositor/Compositor.config
+++ b/Compositor/Compositor.config
@@ -113,6 +113,10 @@ map()
             kv(hdcp2xbinfile ${PLUGIN_COMPOSITOR_HDCP2XBIN_PATH})
         endif(PLUGIN_COMPOSITOR_HDCP2XBIN_PATH)
 
+        if (PLUGIN_COMPOSITOR_LOUDNESS_MODE)
+            kv(loudnessmode ${PLUGIN_COMPOSITOR_LOUDNESS_MODE})
+        endif(PLUGIN_COMPOSITOR_LOUDNESS_MODE)
+
     endif ()
 
 end()

--- a/Compositor/lib/Nexus/NexusServer/NexusServer.cpp
+++ b/Compositor/lib/Nexus/NexusServer/NexusServer.cpp
@@ -102,6 +102,12 @@ namespace Broadcom {
             HDCP22 = NxClient_HdcpVersion_eHdcp22 /* Always authenticate using HDCP 2.2 mode, Content Stream Type 1 */
         };
 
+        enum loudnessmode {
+            LM_NONE = NEXUS_AudioLoudnessEquivalenceMode_eNone, /* Default, no loudness equivalence. */
+            LM_ATSC_A85 = NEXUS_AudioLoudnessEquivalenceMode_eAtscA85, /* ATSC A/85. */
+            LM_EBU_R128 = NEXUS_AudioLoudnessEquivalenceMode_eEbuR128 /* EBU-R128. */
+        };
+
         class MemoryInfo : public Core::JSON::Container {
         private:
             MemoryInfo(const MemoryInfo&) = delete;
@@ -155,6 +161,7 @@ namespace Broadcom {
             , HDCPVersion(AUTO)
             , HDCP1xBinFile()
             , HDCP2xBinFile()
+            , LoudnessMode(LM_NONE)
         {
             Add(_T("irmode"), &IRMode);
             Add(_T("authentication"), &Authentication);
@@ -171,6 +178,7 @@ namespace Broadcom {
             Add(_T("hdcpversion"), &HDCPVersion);
             Add(_T("hdcp1xbinfile"), &HDCP1xBinFile);
             Add(_T("hdcp2xbinfile"), &HDCP2xBinFile);
+            Add(_T("loudnessmode"), &LoudnessMode);
         }
         ~Config()
         {
@@ -192,6 +200,7 @@ namespace Broadcom {
         Core::JSON::EnumType<hdcpversion> HDCPVersion;
         Core::JSON::String HDCP1xBinFile;
         Core::JSON::String HDCP2xBinFile;
+        Core::JSON::EnumType<loudnessmode> LoudnessMode;
     };
 
     /* -------------------------------------------------------------------------------------------------------------
@@ -440,7 +449,7 @@ namespace Broadcom {
             struct nxserver_cmdline_settings cmdline_settings;
             memset(&cmdline_settings, 0, sizeof(cmdline_settings));
             cmdline_settings.frontend = true;
-            cmdline_settings.loudnessMode = NEXUS_AudioLoudnessEquivalenceMode_eNone;
+            cmdline_settings.loudnessMode = static_cast<NEXUS_AudioLoudnessEquivalenceMode>(config.LoudnessMode.Value());
             _serverSettings.session[0].dolbyMs = nxserverlib_dolby_ms_type_none;
 
             if (config.FrameBufferWidth.IsSet() && config.FrameBufferHeight.IsSet()) {
@@ -618,6 +627,14 @@ ENUM_CONVERSION_BEGIN(Broadcom::Config::hdcpversion)
     { Broadcom::Config::HDCP22, _TXT("Hdcp22") },
 
     ENUM_CONVERSION_END(Broadcom::Config::hdcpversion);
+
+ENUM_CONVERSION_BEGIN(Broadcom::Config::loudnessmode)
+
+    { Broadcom::Config::LM_NONE,     _TXT("None")},
+    { Broadcom::Config::LM_ATSC_A85, _TXT("ATSC_A85")},
+    { Broadcom::Config::LM_EBU_R128, _TXT("EBU_R128")},
+
+    ENUM_CONVERSION_END(Broadcom::Config::loudnessmode);
 
 ENUM_CONVERSION_BEGIN(NEXUS_IrInputMode)
 

--- a/Compositor/lib/Nexus/NexusServer/NexusServer.h
+++ b/Compositor/lib/Nexus/NexusServer/NexusServer.h
@@ -111,6 +111,7 @@ namespace Broadcom {
         {
             if ((_joined == false) && (NxClient_Join(&_joinSettings) == NEXUS_SUCCESS)) {
                 _joined = true;
+                NxClient_UnregisterAcknowledgeStandby(NxClient_RegisterAcknowledgeStandby());
             }
             return (_joined);
         }


### PR DESCRIPTION
A few Compositor plugin fixes drafted after NOS testing with the latest framework.

Commit 1 (25e958b704d2) is for unregistering from the Nexus Standby Acknowledgment process. 
For backwards compatibility, by default Nexus has  Standby Acknowledgment enabled for every `NxClient_Join()`.
However, the Compositor is not implementing the Standby Acknowledgment and, as such, it should unregister itself from it, otherwise, when going to standby, Nexus will wait 10 seconds (the default timeout) from this client to acknowledge the standby.  
Any client that does `NxClient_Join()` but doesn't implement StandbyAcknowledgment must unregister itself from the Standby Acknowledgment process. 

Commit 2 (060f0a25e2b6) is to allow configuring the NxServer Audio Loudness Mode via the Compositor's JSON config, similar to what's already being done with some HDCP settings, etc.
The default Audio Loudness Mode doesn't serve all purposes and use cases. For example, to be able to pass Dolby certification, it's required to use a different mode (`NEXUS_AudioLoudnessEquivalenceMode_eEbuR128`). This way, allow configuring this using the same scheme as done already before for other NxServer settings.

All of the changes are required for correct operation of the Compositor plugin under the use cases required by NOS.