### PR TITLE
RemoteControl: Fixes from NOS testing

### DIFF
--- a/RemoteControl/CMakeLists.txt
+++ b/RemoteControl/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(PLUGIN_NAME RemoteControl)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
+set(PLUGIN_REMOTECONTROL_RELEASE_TIMEOUT 30000 CACHE STRING "Remote control release timeout")
+
 option(PLUGIN_REMOTECONTROL_RFCE "Enable RF4CE functionality." ON)
 
 set(PLUGIN_REMOTECONTROL_RFCE_REMOTE_ID "GPSTB" CACHE STRING "User string, used for greenpeak")

--- a/RemoteControl/RemoteControl.config
+++ b/RemoteControl/RemoteControl.config
@@ -4,7 +4,7 @@ set (preconditions Platform)
 map()
     kv(repeatstart 500)
     kv(repeatinterval 100)
-    kv(releasetimeout 30000)
+    kv(releasetimeout ${PLUGIN_REMOTECONTROL_RELEASE_TIMEOUT})
 end()
 ans(configuration)
 


### PR DESCRIPTION
A few RemoteControl plugin changes drafted after NOS testing with the latest framework.

Commit 1 (64aeb5a94d6a) is for making the key release timeout configurable via cmake.
Commit 2 (55dce874ab12) is for fixing a new deadlock use case when plugin activation is done by autostarting it on boot.

All of the changes are required for correct operation of the RemoteControl plugin under the use cases required by NOS.