### PR TITLE
IOConnector: Fixes from NOS testing

### DIFF
--- a/IOConnector/IOConnector.cpp
+++ b/IOConnector/IOConnector.cpp
@@ -161,7 +161,7 @@ namespace Plugin
         Pins::iterator index = _pins.begin();
 
         while ((index != _pins.end()) && (result == nullptr)) {
-            if (index->first->Identifier() == id) {
+            if ((index->first->Identifier() & 0xFFFF) == id) {
                 result = index->first;
                 result->AddRef();
             } else {


### PR DESCRIPTION
The current implementation of IExternal::IFactory::Resource(uint32_t id)
in IOConnector plugin checks the "id" with the GPIO::Pin::Identifier()
for all the GPIO pins we have configured and return pointer to GPIO::Pin
object which matches our "id".

But we need to mask the identifier returned by Identifier() method
before use, This is because when we are creating GPIO::Pin objects the
GPIO pin id is masked with a prefix corresponding to the type of
ExternalBase<> template we are creating.

In our case "class Pin" is created from ExternalBase of type
Exchange::IExternal::GPIO and this our gpio pin id will be masked with
IExternal::identification::GPIO which is 0x20000000. See
Interfaces/IExternal.h for more details.

Thus mask the GPIO::Pin::Identifier() before comparison, We have used
the mask as 0xFFFF and not 0x0FFFFFFF following other places in
IOConnector where it is already used.

All of the changes are required for correct operation of the IOConnector plugin under the use cases required by NOS.