### PR TITLE
enable cursor on westeros compositor

### DIFF
--- a/Compositor/Compositor.config
+++ b/Compositor/Compositor.config
@@ -119,6 +119,7 @@ map()
 
     endif ()
 
+    kv(cursor ${PLUGIN_COMPOSITOR_CURSOR_FILE})
 end()
 ans(configuration)
 

--- a/Compositor/lib/Wayland/CMakeLists.txt
+++ b/Compositor/lib/Wayland/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(${NAMESPACE}Core REQUIRED)
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(${NAMESPACE}Definitions REQUIRED)
 find_package(EGL REQUIRED)
+find_package(PNG REQUIRED)
 
 if (PLUGIN_COMPOSITOR_NXSERVER)
     target_link_libraries(${TARGET} 
@@ -41,6 +42,7 @@ target_link_libraries(${TARGET}
         ${NAMESPACE}Definitions::${NAMESPACE}Definitions
         WaylandServer::WaylandServer
         WaylandEGL::WaylandEGL
+        PNG::PNG
         compositorclient)
 
 target_include_directories(${TARGET}

--- a/Compositor/lib/Wayland/Westeros.cpp
+++ b/Compositor/lib/Wayland/Westeros.cpp
@@ -1,6 +1,8 @@
 #include "Wayland.h"
 #include <westeros-compositor.h>
 
+#include <png.h>
+
 namespace WPEFramework {
 namespace Westeros {
 
@@ -16,6 +18,7 @@ namespace Westeros {
         Compositor(const string& renderModule, const string& display, const uint32_t width, const uint32_t height)
             : _compositor(nullptr)
             , _virtualKeyboardHandle(nullptr)
+            , _cursor(nullptr)
         {
             TRACE(Trace::Information, (_T("Starting Compositor renderModule=%s display=%s"), renderModule.c_str(), display.c_str()));
 
@@ -68,6 +71,7 @@ namespace Westeros {
                 WstCompositorStop(_compositor);
                 WstCompositorDestroy(_compositor);
             }
+            if (_cursor) free(_cursor);
 
             if (_virtualKeyboardHandle != nullptr) {
                 virtualinput_close(_virtualKeyboardHandle);
@@ -161,9 +165,113 @@ namespace Westeros {
         {
         }
 
+        static unsigned char* ReadPNGFile(const char *filename, unsigned char &in_width, unsigned char &in_height)
+        {
+            FILE *fp = fopen(filename, "rb");
+            if(!fp) return NULL;
+
+            png_byte color_type;
+            png_byte bit_depth;
+            png_bytep *row_pointers = NULL;
+
+            png_structp png = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+            if(!png) return NULL;
+
+            png_infop info = png_create_info_struct(png);
+            if(!info) return NULL;
+
+            if(setjmp(png_jmpbuf(png))) return NULL;
+
+            png_init_io(png, fp);
+
+            png_read_info(png, info);
+
+            in_width   = png_get_image_width(png, info);
+            in_height  = png_get_image_height(png, info);
+            color_type = png_get_color_type(png, info);
+            bit_depth  = png_get_bit_depth(png, info);
+
+            // Read any color_type into 8bit depth, RGBA format.
+            // See http://www.libpng.org/pub/png/libpng-manual.txt
+            if(bit_depth == 16)
+              png_set_strip_16(png);
+
+            if(color_type == PNG_COLOR_TYPE_PALETTE)
+              png_set_palette_to_rgb(png);
+
+            // PNG_COLOR_TYPE_GRAY_ALPHA is always 8 or 16bit depth.
+            if(color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
+              png_set_expand_gray_1_2_4_to_8(png);
+
+            if(png_get_valid(png, info, PNG_INFO_tRNS))
+              png_set_tRNS_to_alpha(png);
+
+            // These color_type don't have an alpha channel then fill it with 0xff.
+            if(color_type == PNG_COLOR_TYPE_RGB ||
+               color_type == PNG_COLOR_TYPE_GRAY ||
+               color_type == PNG_COLOR_TYPE_PALETTE)
+              png_set_filler(png, 0xFF, PNG_FILLER_AFTER);
+
+            if(color_type == PNG_COLOR_TYPE_GRAY ||
+               color_type == PNG_COLOR_TYPE_GRAY_ALPHA)
+              png_set_gray_to_rgb(png);
+
+            png_read_update_info(png, info);
+
+            if (row_pointers) return NULL;
+
+            row_pointers = (png_bytep*)malloc(sizeof(png_bytep) * in_height);
+            for(int y = 0; y < in_height; y++)
+              row_pointers[y] = (png_byte*)malloc(png_get_rowbytes(png,info));
+
+            png_read_image(png, row_pointers);
+
+            unsigned char* data = (unsigned char*)malloc(in_height * in_width * 4 /*each pixel in 4 bytes */);
+            for(int y = 0, i = 0; y < in_height; y++) {
+               memcpy(data + i, row_pointers[y], png_get_rowbytes(png,info));
+               free(row_pointers[y]);
+               i += png_get_rowbytes(png,info);
+            }
+            free(row_pointers);
+
+            fclose(fp);
+            png_destroy_read_struct(&png, &info, NULL);
+
+            return data;
+        }
+
+    public:
+        bool setCursor(const string& cursorFile)
+        {
+            if(_cursor) free(_cursor);
+
+            unsigned char width = 0, height = 0;
+            _cursor = ReadPNGFile(cursorFile.c_str(), width, height);
+            if(!_cursor)
+            {
+                TRACE(Trace::Error, (_T("Unable to read given cursor PNG file %s"), cursorFile.c_str()));
+                return false;
+            }
+            TRACE(Trace::Information, (_T("cursor: height %d, width %d\n"), height, width));
+
+            if(!WstCompositorSetDefaultCursor( _compositor, _cursor, width, height, 0, 0 ))
+            {
+                const char *detail= WstCompositorGetLastErrorDetail(_compositor);
+                TRACE(Trace::Error, (_T("Unable to set default cursor: error: (%s)\n"), detail));
+                return false;
+            }
+            else
+            {
+                TRACE(Trace::Information, (_T("mouse pointer cursor enabled")));
+                /*TODO - create a thread to handle mouse input handler*/
+            }
+            return true;
+        }
+
     private:
         WstCompositor* _compositor;
         void* _virtualKeyboardHandle;
+        unsigned char* _cursor;
         static Westeros::Compositor* _instance;
     };
 
@@ -183,9 +291,11 @@ namespace Implementation {
             : Core::JSON::Container()
             , Renderer(_T("/usr/lib/libwesteros_render_gl.so"))
             , Display(_T("wayland-0"))
+            , Cursor(_T(""))
         {
             Add(_T("renderer"), &Renderer);
             Add(_T("display"), &Display);
+            Add(_T("cursor"), &Cursor);
             Add(_T("width"), &Width);
             Add(_T("height"), &Height);
         }
@@ -196,6 +306,7 @@ namespace Implementation {
     public:
         Core::JSON::String Renderer;
         Core::JSON::String Display;
+        Core::JSON::String Cursor;
         Core::JSON::DecUInt32 Width;
         Core::JSON::DecUInt32 Height;
     };
@@ -207,7 +318,12 @@ namespace Implementation {
         Config config;
         config.FromString(service->ConfigLine());
 
-        return Westeros::Compositor::Create(config.Renderer.Value(), config.Display.Value(), config.Width.Value(), config.Height.Value());
+        Westeros::Compositor* instance = Westeros::Compositor::Create(config.Renderer.Value(), config.Display.Value(), config.Width.Value(), config.Height.Value());
+        string cursor = config.Cursor.Value();
+        if(!cursor.empty()) {
+            instance->setCursor(cursor);
+        }
+        return instance;
     }
 } // namespace Implementation
 }


### PR DESCRIPTION
    - introduced new field in json config for cursor file
    - enabling cursor only if any file mentioned in the json config
    - reading PNG image in ARGB888 format as westeros expects

Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>