### PR TITLE
power: Adds an option in power plugin for not to register for KEY_POWER event

### DIFF
--- a/Power/CMakeLists.txt
+++ b/Power/CMakeLists.txt
@@ -4,6 +4,7 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 set(PLUGIN_POWER_AUTOSTART true CACHE STRING true)
 set(PLUGIN_POWER_GPIOPIN "" CACHE STRING "GPIO pin number")
 set(PLUGIN_POWER_GPIOTYPE "" CACHE STRING "GPIO type")
+option(PLUGIN_POWER_REGISTER_KEY_POWER "Plugin register for KEY_POWER" ON)
 
 find_package(NEXUS REQUIRED)
 find_package(NXCLIENT REQUIRED)
@@ -11,6 +12,10 @@ find_package(BcmPowerManager REQUIRED)
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(${NAMESPACE}Definitions REQUIRED)
 find_package(CompileSettingsDebug CONFIG REQUIRED)
+
+if(NOT PLUGIN_POWER_REGISTER_KEY_POWER)
+  add_definitions(-DDONT_REGISTER_FOR_KEY_POWER)
+endif()
 
 add_library(${MODULE_NAME} SHARED 
     Power.cpp

--- a/Power/Power.cpp
+++ b/Power/Power.cpp
@@ -23,11 +23,13 @@ namespace Plugin {
         _power = Core::ServiceAdministrator::Instance().Instantiate<Exchange::IPower>(Core::Library(), _T("PowerImplementation"), static_cast<uint32_t>(~0));
 
         if (_power != nullptr) {
+#ifndef DONT_REGISTER_FOR_KEY_POWER
             PluginHost::VirtualInput* keyHandler(PluginHost::InputHandler::Handler());
 
             ASSERT(keyHandler != nullptr);
 
             keyHandler->Register(&_sink, KEY_POWER);
+#endif
 
             // Receive all plugin information on state changes.
             _service->Register(&_sink);
@@ -55,11 +57,13 @@ namespace Plugin {
         // Remove all registered clients
         _clients.clear();
 
+#ifndef DONT_REGISTER_FOR_KEY_POWER
         // Also we are nolonger interested in the powerkey events, we have been requested to shut down our services!
         PluginHost::VirtualInput* keyHandler(PluginHost::InputHandler::Handler());
 
         ASSERT(keyHandler != nullptr);
         keyHandler->Unregister(&_sink, KEY_POWER);
+#endif
 
         _power->Unregister(&_sink);
 


### PR DESCRIPTION
In the original implementation of the power plugin, plugin is
registering for getting KEY_POWER notifications from the remote. Based
on this event power plugin is controlling the power state. In some
cases, the power state changes should be managed by an managing
application/ plugin and in this case, the power key will interfere
with the manager app. So there should be a way to tell the power plugin
not to register for KEY_POWER events.
This commit adds a configuration option to do the same. In the default
build, the power plugin will register for the KEY_POWER. To disable this
feature, one need to set `PLUGIN_POWER_REGISTER_KEY_POWER` to `OFF` from
a recipe.