### PR TITLE
power: fixes power plugin not getting build for nexus

### DIFF
--- a/Power/CMakeLists.txt
+++ b/Power/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories( ${MODULE_NAME}
         PUBLIC
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
-if (LIBNXSERVER_FOUND)
+if (NXCLIENT_FOUND)
     message("Building the Nexus....")
     target_sources(${MODULE_NAME} PRIVATE PowerImplementation/Broadcom/PowerImplementation.cpp)
     target_link_libraries(${MODULE_NAME} 
@@ -49,8 +49,10 @@ target_link_libraries(${MODULE_NAME}
 
 if (BCM_PM_FOUND)
     set(POWER_LIBS -Wl,--whole-archive ${BCM_PM_LIBRARIES} -Wl,--no-whole-archive)
-    list(APPEND PLUGIN_LIBS ${POWER_LIBS})
 
+    target_link_libraries(${MODULE_NAME}
+        PRIVATE
+        ${POWER_LIBS})
 
 endif ()
 

--- a/Power/PowerImplementation/Broadcom/PowerImplementation.cpp
+++ b/Power/PowerImplementation/Broadcom/PowerImplementation.cpp
@@ -407,7 +407,7 @@ Exchange::IPower::PCStatus PowerImplementation::SetPowerState()
 {
     TRACE(Trace::Information, (_T("SetPowerState")));
     NxClient_StandbySettings standbySettings;
-    PCState pState;
+    PCState pState = On;
 
     NxClient_GetDefaultStandbySettings(&standbySettings);
     standbySettings.settings.mode = _mode;
@@ -432,9 +432,6 @@ Exchange::IPower::PCStatus PowerImplementation::SetPowerState()
             break;
         case NEXUS_PlatformStandbyMode_eDeepSleep:
             pState = SuspendToRAM;
-            break;
-        case NEXUS_PlatformStandbyMode_eDeepSleep:
-            pState = PowerOff;
             break;
     }
     NotifyStateChange(pState);


### PR DESCRIPTION
It was observed that the Power plugin was not getting build for the
nexus when even if nexus is available. The reason being that the check
to build with nexus was using wrong variable after the refactoring.
Also, the pmlibs where not even getting linked resulting in undefined
references.