### PR TITLE
RemoteControl: Fixes from NOS testing

### DIFF
--- a/RemoteControl/GreenPeak.cpp
+++ b/RemoteControl/GreenPeak.cpp
@@ -209,7 +209,7 @@ namespace Plugin {
         {
             return (_readySignal.Lock(time) == 0);
         }
-        virtual const TCHAR* Name() const override
+        string Name() const override
         {
             return (_resourceName.c_str());
         }

--- a/RemoteControl/RemoteControl.cpp
+++ b/RemoteControl/RemoteControl.cpp
@@ -170,7 +170,8 @@ namespace Plugin {
 
             while (index.Next() == true) {
 
-                string loadName((*index)->Name());
+                string producer((*index)->Name());
+                string loadName(producer);
 
                 TRACE_L1(_T("Searching map file for: %s"), loadName.c_str());
 
@@ -197,7 +198,7 @@ namespace Plugin {
                     TRACE_L1(_T("Opening map file: %s"), specific.c_str());
 
                     // Get our selves a table..
-                    PluginHost::VirtualInput::KeyMap& map(_inputHandler->Table(loadName.c_str()));
+                    PluginHost::VirtualInput::KeyMap& map(_inputHandler->Table(producer.c_str()));
                     map.Load(specific);
                     if (configList.IsValid() == true) {
                         map.PassThrough(configList.Current().PassOn.Value());


### PR DESCRIPTION
A couple of fixes around the RemoteControl from NOS testing with the latest Thunder and ThunderNanoServices.

Commit 1 (0108f497b847) fixes a build issue for the GreenPeak implementation caused by an interface change in the `IKeyProducer::Name()` method (returning `string` instead of `TCHAR *`).
Commit 2 (d942a5f488f9) fixes the key (name) when registering the device specific key map file (regression from 4002913b272b).