### PR TITLE
WebKit, Spark: release StateControl after use

### DIFF
--- a/Spark/SparkJsonRpc.cpp
+++ b/Spark/SparkJsonRpc.cpp
@@ -122,6 +122,8 @@ namespace Plugin {
         PluginHost::IStateControl::state currentState = stateControl->State();
         response = (currentState == PluginHost::IStateControl::SUSPENDED? StateType::SUSPENDED : StateType::RESUMED);
 
+        stateControl->Release();
+
         return Core::ERROR_NONE;
     }
 

--- a/WebKitBrowser/WebKitBrowserJsonRpc.cpp
+++ b/WebKitBrowser/WebKitBrowserJsonRpc.cpp
@@ -123,6 +123,8 @@ namespace Plugin {
         PluginHost::IStateControl::state currentState = stateControl->State();
         response = (currentState == PluginHost::IStateControl::SUSPENDED? StateType::SUSPENDED : StateType::RESUMED);
 
+        stateControl->Release();
+
         return Core::ERROR_NONE;
     }
 


### PR DESCRIPTION
This issue is causing hang on the WebKit plugin, once we call a state() through the json rpc (or just load the Controller UI for WebKitBrowser info/settigns)