### PR TITLE
power: Adds configuration option to register power key and control cl…

### DIFF
--- a/Power/CMakeLists.txt
+++ b/Power/CMakeLists.txt
@@ -4,6 +4,12 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 set(PLUGIN_POWER_AUTOSTART true CACHE STRING true)
 set(PLUGIN_POWER_GPIOPIN "" CACHE STRING "GPIO pin number")
 set(PLUGIN_POWER_GPIOTYPE "" CACHE STRING "GPIO type")
+# PLUGIN_POWER_POWER_KEY is for setting the keycode of the key that needs to be configured as power button.
+# default value `116` corresponds to KEY_POWER. This value comes from input-event-codes.h
+# https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+# If this feature is not needed, set this value to 0
+set(PLUGIN_POWER_POWER_KEY 116 CACHE STRING "Key Code for power key. To disable set this to 0")
+set(PLUGIN_POWER_CONTROL_CLIENTS true CACHE STRING "Control plugins with IStateControl interface")
 
 find_package(NEXUS REQUIRED)
 find_package(NXCLIENT REQUIRED)

--- a/Power/Power.config
+++ b/Power/Power.config
@@ -3,6 +3,8 @@ set (preconditions Platform)
 
 if (PLUGIN_POWER_GPIOTYPE AND PLUGIN_POWER_GPIOPIN)
 map()
+   kv(powerkey ${PLUGIN_POWER_POWER_KEY})
+   kv(controlclients ${PLUGIN_POWER_CONTROL_CLIENTS})
    kv(gpiopin ${PLUGIN_POWER_GPIOPIN})
    kv(gpiotype ${PLUGIN_POWER_GPIOTYPE})
 end()

--- a/Power/Power.h
+++ b/Power/Power.h
@@ -112,8 +112,12 @@ namespace Plugin {
             Config()
                 : Core::JSON::Container()
                 , OutOfProcess(true)
+                , PowerKey(0)
+                , ControlClients(true)
             {
                 Add(_T("outofprocess"), &OutOfProcess);
+                Add(_T("powerkey"), &PowerKey);
+                Add(_T("controlclients"), &ControlClients);
             }
             ~Config()
             {
@@ -121,6 +125,8 @@ namespace Plugin {
 
         public:
             Core::JSON::Boolean OutOfProcess;
+            Core::JSON::DecUInt32 PowerKey;
+            Core::JSON::Boolean ControlClients;
         };
 
         typedef std::map<const string, Entry> Clients;
@@ -163,6 +169,8 @@ namespace Plugin {
             , _clients()
             , _power(nullptr)
             , _sink(this)
+            , _powerKey(0)
+            , _controlClients(true)
         {
             RegisterAll();
         }
@@ -229,6 +237,8 @@ namespace Plugin {
         Clients _clients;
         Exchange::IPower* _power;
         Core::Sink<Notification> _sink;
+        uint32_t _powerKey;
+        bool _controlClients;
     };
 } //namespace Plugin
 } //namespace WPEFramework


### PR DESCRIPTION
…ients

This commit is for adding an config option to decide on whether to
register for power key or to control the client with IStateControl
interface. This is done by adding additional configuration options
* PLUGIN_POWER_POWER_KEY: for setting the keycode of the remote key that
    will be used as the power key. If power plugin doesn't want to
    manage the power on key press, set this to 0. by default, the value
    is set to 116 (POWER_KEY from
    https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h)

* PLUGIN_POWER_CONTROL_CLIENTS: decide whether power plugin needs to
    control the states of other plugin implementing IStateControl. The
    default value is set to true.