### PR TITLE
Streamer: fix to avoid crash during the stop

### DIFF
--- a/Streamer/Frontend.h
+++ b/Streamer/Frontend.h
@@ -88,6 +88,9 @@ namespace Player {
                 uint32_t Release() const override
                 {
                     if (Core::InterlockedDecrement(_referenceCount) == 0) {
+
+                        ASSERT(_callback == nullptr);
+
                         if (_callback != nullptr) {
                             _callback->Release();
                         }
@@ -253,6 +256,8 @@ namespace Player {
                     ASSERT(_player != nullptr);
                     ASSERT(_administrator != nullptr);
                     _player->Callback(nullptr);
+
+                    ASSERT(_callback == nullptr);
                     if (_callback) {
                         _callback->Release();
                     }

--- a/Streamer/Frontend.h
+++ b/Streamer/Frontend.h
@@ -78,6 +78,10 @@ namespace Player {
                 ~DecoderImplementation() override
                 {
                     _parent.Detach();
+                    if (_callback != nullptr) {
+                        _callback->Release();
+                        _callback = nullptr;
+                    }
                 }
 
             public:
@@ -88,9 +92,6 @@ namespace Player {
                 uint32_t Release() const override
                 {
                     if (Core::InterlockedDecrement(_referenceCount) == 0) {
-                        if (_callback != nullptr) {
-                            _callback->Release();
-                        }
                         delete this;
                         return (Core::ERROR_DESTRUCTION_SUCCEEDED);
                     }

--- a/Streamer/Frontend.h
+++ b/Streamer/Frontend.h
@@ -78,10 +78,6 @@ namespace Player {
                 ~DecoderImplementation() override
                 {
                     _parent.Detach();
-                    if (_callback != nullptr) {
-                        _callback->Release();
-                        _callback = nullptr;
-                    }
                 }
 
             public:
@@ -92,6 +88,9 @@ namespace Player {
                 uint32_t Release() const override
                 {
                     if (Core::InterlockedDecrement(_referenceCount) == 0) {
+                        if (_callback != nullptr) {
+                            _callback->Release();
+                        }
                         delete this;
                         return (Core::ERROR_DESTRUCTION_SUCCEEDED);
                     }

--- a/Streamer/StreamerJsonRpc.cpp
+++ b/Streamer/StreamerJsonRpc.cpp
@@ -109,6 +109,7 @@ namespace Plugin {
         if (stream != _streams.end()) {
             Controls::iterator control = _controls.find(id);
             if (control != _controls.end()) {
+                control->second->Callback(nullptr);
                 uint32_t relResult = control->second->Release();
                 if (relResult == Core::ERROR_DESTRUCTION_SUCCEEDED) {
                     _controls.erase(control);
@@ -118,6 +119,7 @@ namespace Plugin {
             }
 
             if (result == Core::ERROR_NONE) {
+                stream->second->Callback(nullptr);
                 stream->second->Release();
                 _streams.erase(stream);
             }
@@ -210,6 +212,7 @@ namespace Plugin {
         if (stream != _streams.end()) {
             Controls::iterator control = _controls.find(id);
             if (control != _controls.end()) {
+                control->second->Callback(nullptr);
                 if (control->second->Release() == Core::ERROR_DESTRUCTION_SUCCEEDED) {
                     _controls.erase(id);
                 } else {


### PR DESCRIPTION
During the stop sequence Player is firing the StateChange event through the decoder Event interface. This interface use registered callback to send to the requesters. But this callback is releasing before detaching the player and not setting it to nullptr