### PR TITLE
[Nexus] Unregister standby acknowledgements after joining

### DIFF
--- a/DeviceIdentification/Implementation/Nexus/Nexus.cpp
+++ b/DeviceIdentification/Implementation/Nexus/Nexus.cpp
@@ -46,6 +46,7 @@ public:
     {
         NEXUS_Error rc = NxClient_Join(NULL);
         ASSERT(!rc);
+        NxClient_UnregisterAcknowledgeStandby(NxClient_RegisterAcknowledgeStandby());
 
         if (rc == NEXUS_SUCCESS) {
             NEXUS_Platform_GetConfiguration(&_platformConfig);

--- a/DisplayInfo/Nexus/PlatformImplementation.cpp
+++ b/DisplayInfo/Nexus/PlatformImplementation.cpp
@@ -43,6 +43,7 @@ public:
 
         NEXUS_Error rc = NxClient_Join(NULL);
         ASSERT(!rc);
+        NxClient_UnregisterAcknowledgeStandby(NxClient_RegisterAcknowledgeStandby());
         NEXUS_Platform_GetConfiguration(&_platformConfig);
 
         UpdateTotalGpuRam(_totalGpuRam);

--- a/RemoteControl/IRRemote.cpp
+++ b/RemoteControl/IRRemote.cpp
@@ -142,6 +142,7 @@ namespace Plugin {
 
         rc = NxClient_Join(nullptr);
         ASSERT(rc == NEXUS_SUCCESS);
+        NxClient_UnregisterAcknowledgeStandby(NxClient_RegisterAcknowledgeStandby());
 
         NxClient_GetDefaultAllocSettings(&allocSettings);
         allocSettings.inputClient = 1;

--- a/VolumeControl/Nexus/VolumeControlPlatform.cpp
+++ b/VolumeControl/Nexus/VolumeControlPlatform.cpp
@@ -43,6 +43,7 @@ public:
       NxClient_GetDefaultJoinSettings(&joinSettings);
       snprintf(joinSettings.name, NXCLIENT_MAX_NAME, "%s", "wpevolumecontrol");
       NxClient_Join(&joinSettings);
+      NxClient_UnregisterAcknowledgeStandby(NxClient_RegisterAcknowledgeStandby());
   }
 
   ~VolumeControlPlatformNexus() override


### PR DESCRIPTION
By default, Nexus expects will wait for all joined clients to
acknowledge standby notifications when using Nexus for going to standby.
It waits for those acknowledgments for some time (usually 10 secs)
before going to standby, which causes a large delay to complete standby
in case the clients don't acknowledge.

All plugins currently joining Nexus are, by default, not acknowledging
the standby, so they should call NxClient_UnregisterAcknowledgeStandby()
after joining so that Nexus doesn't wait for them when going to standby.

Make the NxClient_UnregisterAcknowledgeStandby() after NxClient_Join()
for all plugins currently joining Nexus and not doing any standby
acknowledgement.